### PR TITLE
add lending reach subcommand

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -146,6 +146,14 @@ async def lending_walls(ctx, arg='100'):
     msg = await ld.kucoin_lending_get_walls(kucoin, min_size)
     await ctx.send(msg)
 
+@lending.command(name='reach', brief="How much needs to be borrowed to reach a specific rate", aliases=['r'])
+async def lending_reach(ctx, arg='2.0'):
+    try:
+        rate_to_reach = float(arg)
+    except ValueError:
+        rate_to_reach = 2.0
+    msg = ld.kucoin_lending_reach_rate(kucoin, rate_to_reach)
+    await ctx.send(msg)
 
 @bot.event
 async def on_ready():

--- a/lending.py
+++ b/lending.py
@@ -66,4 +66,4 @@ def kucoin_lending_reach_rate(kucoin, rate_to_reach: float):
     rates = kucoin_lending_merge_interest_rate(resp['data'])
     amounts = [size for (rate, size) in rates if (float(rate) * 100) <= rate_to_reach]
     total = reduce(lambda x, y: x+y, amounts)
-    return f"`⟶ {rate_to_reach}%: {total:9,.0f} USDT needs to borrowed`"
+    return f"`⟶ {rate_to_reach}%: {total:9,.0f} USDT needs to be borrowed`"

--- a/lending.py
+++ b/lending.py
@@ -1,6 +1,7 @@
 import io
 import pandas as pd
 import matplotlib.pyplot as plt
+from functools import reduce
 
 plt.style.use('ggplot')
 
@@ -56,3 +57,13 @@ KuCoin Crypto Lending USDT walls (minimum of {:d}k):
 {}
 ```
 '''.format(min_size,"\n".join(walls[:length]))
+
+def kucoin_lending_reach_rate(kucoin, rate_to_reach: float):
+    resp = kucoin.private_get_margin_market({'currency': 'USDT'})
+    if resp['code'] != '200000':
+        return f"KuCoin system error code: {resp['code']}"
+
+    rates = kucoin_lending_merge_interest_rate(resp['data'])
+    amounts = [size for (rate, size) in rates if (float(rate) * 100) <= rate_to_reach]
+    total = reduce(lambda x, y: x+y, amounts)
+    return f"`⟶ {rate_to_reach}%: {total:9,.0f} USDT needs to borrowed`"

--- a/lending.py
+++ b/lending.py
@@ -65,5 +65,7 @@ def kucoin_lending_reach_rate(kucoin, rate_to_reach: float):
 
     rates = kucoin_lending_merge_interest_rate(resp['data'])
     amounts = [size for (rate, size) in rates if (float(rate) * 100) <= rate_to_reach]
-    total = reduce(lambda x, y: x+y, amounts)
+    total = 0
+    if len(amounts):
+        total = reduce(lambda x, y: x+y, amounts)
     return f"`⟶ {rate_to_reach}%: {total:9,.0f} USDT needs to be borrowed`"


### PR DESCRIPTION
Cette commande permet d'afficher la quantité d'USDT à écouler avant d'atteindre un certain taux. Exemple: `!lending reach 0.4`
```
⟶ 0.4%: 1,298,529 USDT needs to borrowed
```