### PR TITLE
Changement de l'affichage de `walls`

### DIFF
--- a/lending.py
+++ b/lending.py
@@ -47,9 +47,9 @@ async def kucoin_lending_get_walls(kucoin, min_size, length=10):
     if resp['code'] != '200000':
         return f"KuCoin system error code: {resp['code']}"
 
-    raw_walls = kucoin_lending_merge_interest_rate(resp['data'])
-    walls = [f"- {float(rate) * 100:<5.3} :: {size:9,.0f} USDT"
-             for (rate, size) in raw_walls if (size / 1000) >= min_size]
+    rates = kucoin_lending_merge_interest_rate(resp['data'])
+    walls = [f"⟶ {float(rate) * 100:<5.3} :: {size:9,.0f} USDT"
+             for (rate, size) in rates if (size / 1000) >= min_size]
     return '''
 KuCoin Crypto Lending USDT walls (minimum of {:d}k):
 ```


### PR DESCRIPTION
Pour uniformiser un peu les sorties des commandes de `lending`.

Nouvel affichage:
```
⟶ 0.278 ::   122,192 USDT
⟶ 0.3   ::   125,279 USDT
⟶ 0.35  ::   114,340 USDT
⟶ 0.376 ::   128,882 USDT
⟶ 0.4   ::   114,405 USDT
⟶ 0.5   :: 1,112,115 USDT
⟶ 0.58  ::   500,510 USDT
⟶ 0.599 ::   161,720 USDT
⟶ 0.6   ::   503,333 USDT
⟶ 1.0   :: 1,637,873 USDT
```